### PR TITLE
Add client-side cache for news items

### DIFF
--- a/client/src/components/NewsTimeline.tsx
+++ b/client/src/components/NewsTimeline.tsx
@@ -5,6 +5,7 @@ import { LoadingSpinner } from './LoadingSpinner';
 import { NewContentBanner } from './NewContentBanner';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { AI_CATEGORIES } from '../lib/constants';
+import { getCachedData, setCachedData } from '../lib/utils';
 
 interface AINewsItem {
   id: string;
@@ -79,6 +80,9 @@ export function NewsTimeline({ selectedSource }: NewsTimelineProps) {
   // 定期的な更新間隔（ミリ秒）
   const AUTO_REFRESH_INTERVAL = 60000; // 1分
   
+  // キャッシュキー（ソース・カテゴリ別）
+  const cacheKey = `news:${selectedSource ?? 'all'}:${selectedCategory ?? 'all'}`;
+
   // React Queryを使用したキャッシュ対応データフェッチ
   const { data: news, isLoading, error, refetch } = useQuery<AINewsItem[], Error>({
     queryKey: ['news', selectedSource, selectedCategory],
@@ -106,6 +110,11 @@ export function NewsTimeline({ selectedSource }: NewsTimelineProps) {
     },
     staleTime: 60000, // 1分間はキャッシュを新鮮とみなす
     refetchOnWindowFocus: false, // ウィンドウフォーカス時に再取得しない
+    initialData: () =>
+      getCachedData<AINewsItem[]>(cacheKey, 5 * 60 * 1000) ?? undefined,
+    onSuccess: data => {
+      setCachedData(cacheKey, data);
+    },
   });
   
   // 追加のアイテムを読み込む関数

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -11,6 +11,30 @@ const setLocalStorage = (key: string, value: any): void =>
   window.localStorage.setItem(key, JSON.stringify(value));
 
 /**
+ * シンプルなローカルストレージキャッシュ取得
+ * @param key ストレージキー
+ * @param maxAge 有効期限（ms）
+ */
+export function getCachedData<T>(key: string, maxAge: number): T | null {
+  const cached = getLocalStorage(key);
+  if (!cached) return null;
+  if (Date.now() - cached.timestamp > maxAge) {
+    window.localStorage.removeItem(key);
+    return null;
+  }
+  return cached.data as T;
+}
+
+/**
+ * ローカルストレージにキャッシュを保存
+ * @param key ストレージキー
+ * @param data 保存するデータ
+ */
+export function setCachedData(key: string, data: unknown): void {
+  setLocalStorage(key, { timestamp: Date.now(), data });
+}
+
+/**
  * HTMLタグを除去するヘルパー関数
  */
 export function stripHtmlTags(html: string): string {
@@ -33,4 +57,4 @@ export function stripHtmlTags(html: string): string {
   return plainText;
 }
 
-export { getLocalStorage, setLocalStorage };
+export { getLocalStorage, setLocalStorage, getCachedData, setCachedData };


### PR DESCRIPTION
## Summary
- cache fetched news in `localStorage`
- read from cache on load to show data faster

## Testing
- `npm run check` *(fails: Cannot find type definition file)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fe25a81c832a9e010ca4fadf4247