### PR TITLE
Add share to X support in article detail view

### DIFF
--- a/client/src/components/ArticleDetailView.tsx
+++ b/client/src/components/ArticleDetailView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { stripHtmlTags } from '../lib/utils';
 import { BookmarkButton } from './BookmarkButton';
+import { ShareButton } from './ShareButton';
 
 interface AINewsItem {
   id: string;
@@ -84,6 +85,7 @@ export function ArticleDetailView({
   
   const summary = getSummary();
   const firstParagraph = getFirstParagraph();
+  const shareSummary = summary || firstParagraph;
   
   // 要約と最初の段落の長さをログに出力（デバッグ用）
   console.log('記事詳細 - コンテンツサイズ:', {
@@ -178,27 +180,36 @@ export function ArticleDetailView({
         
         {/* フッター（固定） */}
         <footer className="p-3 md:p-4 border-t border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-          <button 
-            onClick={() => window.open(article.link, '_blank', 'noopener,noreferrer')} 
-            className="w-full flex items-center justify-center gap-1.5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors text-sm font-medium"
-          >
-            <span>続きを元の記事で読む</span>
-            <svg 
-              xmlns="http://www.w3.org/2000/svg" 
-              width="16" 
-              height="16" 
-              viewBox="0 0 24 24" 
-              fill="none" 
-              stroke="currentColor" 
-              strokeWidth="2" 
-              strokeLinecap="round" 
-              strokeLinejoin="round"
+          <div className="flex flex-col md:flex-row gap-2">
+            <ShareButton
+              title={displayTitle}
+              url={article.link}
+              categories={article.categories}
+              summary={shareSummary}
+              className="w-full md:w-auto flex-1 rounded-lg border-blue-600 text-blue-600 hover:bg-blue-50 dark:border-blue-500 dark:text-blue-300 dark:hover:bg-slate-800"
+            />
+            <button
+              onClick={() => window.open(article.link, '_blank', 'noopener,noreferrer')}
+              className="w-full md:w-auto flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors text-sm font-medium"
             >
-              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-              <polyline points="15 3 21 3 21 9"></polyline>
-              <line x1="10" y1="14" x2="21" y2="3"></line>
-            </svg>
-          </button>
+              <span>続きを元の記事で読む</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <line x1="10" y1="14" x2="21" y2="3"></line>
+              </svg>
+            </button>
+          </div>
         </footer>
       </div>
     </div>

--- a/client/src/components/ShareButton.tsx
+++ b/client/src/components/ShareButton.tsx
@@ -1,0 +1,46 @@
+import { MouseEvent } from 'react';
+import { cn } from '../lib/utils';
+import { shareArticleToX, ShareArticleToXOptions } from '../lib/share';
+
+interface ShareButtonProps extends ShareArticleToXOptions {
+  label?: string;
+  className?: string;
+}
+
+export function ShareButton({
+  title,
+  url,
+  categories,
+  summary,
+  label = 'Xでシェア',
+  className
+}: ShareButtonProps) {
+  const handleShare = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    await shareArticleToX({ title, url, categories, summary });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className={cn(
+        'inline-flex items-center justify-center gap-1.5 rounded-full border border-slate-200 bg-white/80 px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200 dark:hover:bg-slate-700',
+        className
+      )}
+      aria-label={label}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="h-4 w-4"
+        aria-hidden="true"
+      >
+        <path d="M4.5 4h4.2l3.18 4.68L15.9 4H20l-6.3 7.23L20 20h-4.2l-3.44-4.95L8.1 20H4l6.39-7.35L4.5 4Z" />
+      </svg>
+      {label && <span>{label}</span>}
+    </button>
+  );
+}

--- a/client/src/lib/share.ts
+++ b/client/src/lib/share.ts
@@ -1,0 +1,103 @@
+export const MAX_X_POST_LENGTH = 280;
+
+export interface BuildXShareTextOptions {
+  title: string;
+  url: string;
+  categories?: string[];
+  summary?: string;
+}
+
+const sanitizeCategoryForHashtag = (category: string): string => {
+  return category
+    .normalize('NFKC')
+    .replace(/[\s\u3000]+/gu, '')
+    .replace(/[^0-9A-Za-z\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9faf\u3005\u303b]+/gu, '');
+};
+
+const createHashtags = (categories: string[] = []): string[] => {
+  const uniqueTags = new Set<string>();
+  categories.forEach(category => {
+    const sanitized = sanitizeCategoryForHashtag(category);
+    if (sanitized) {
+      uniqueTags.add(`#${sanitized}`);
+    }
+  });
+  return Array.from(uniqueTags);
+};
+
+const composeShareText = (
+  title: string,
+  url: string,
+  hashtags: string[],
+  summary?: string
+): string => {
+  const parts: string[] = [];
+  if (title.trim()) {
+    parts.push(title.trim());
+  }
+  if (summary && summary.trim()) {
+    parts.push(summary.trim());
+  }
+  if (url.trim()) {
+    parts.push(url.trim());
+  }
+  if (hashtags.length > 0) {
+    parts.push(hashtags.join(' '));
+  }
+  return parts.join('\n\n');
+};
+
+export function buildXShareText({
+  title,
+  url,
+  categories = [],
+  summary
+}: BuildXShareTextOptions): string {
+  const hashtags = createHashtags(categories);
+  const normalizedSummary = summary
+    ?.replace(/\s+/gu, ' ')
+    .trim();
+
+  const withSummary = composeShareText(title, url, hashtags, normalizedSummary);
+  if (withSummary.length <= MAX_X_POST_LENGTH) {
+    return withSummary;
+  }
+
+  const withoutSummary = composeShareText(title, url, hashtags);
+  if (withoutSummary.length <= MAX_X_POST_LENGTH) {
+    return withoutSummary;
+  }
+
+  return withoutSummary.slice(0, MAX_X_POST_LENGTH);
+}
+
+export interface ShareArticleToXOptions extends BuildXShareTextOptions {}
+
+export async function shareArticleToX(options: ShareArticleToXOptions): Promise<void> {
+  const text = buildXShareText(options);
+
+  if (typeof navigator !== 'undefined') {
+    const nav = navigator as Navigator & {
+      share?: (data?: ShareData) => Promise<void>;
+    };
+
+    if (typeof nav.share === 'function') {
+      try {
+        await nav.share({ text, url: options.url });
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        console.warn('Navigator share failed, falling back to intent URL.', error);
+      }
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    const shareIntentUrl = new URL('https://twitter.com/intent/tweet');
+    shareIntentUrl.searchParams.set('text', text);
+    shareIntentUrl.searchParams.set('url', options.url);
+    window.open(shareIntentUrl.toString(), '_blank', 'noopener,noreferrer');
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary
- add a share helper that builds X share text with hashtags and navigator/share fallback
- introduce a reusable ShareButton component powered by the new helper
- surface an "Xでシェア" option in the article detail footer that adapts to the original/translated view

## Testing
- not run (no lint script available)


------
https://chatgpt.com/codex/tasks/task_e_68f4aa07e04c832a8dd476509742ab25


___

### **PR Type**
Enhancement


___

### **Description**
- Add X share functionality with text composition and hashtag support

- Create reusable ShareButton component for article sharing

- Integrate share button into article detail footer alongside read more button

- Support both Web Share API and Twitter intent URL fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Article Detail View"] -->|"passes article data"| B["ShareButton Component"]
  B -->|"calls"| C["shareArticleToX function"]
  C -->|"builds text"| D["buildXShareText"]
  D -->|"creates hashtags"| E["sanitizeCategoryForHashtag"]
  C -->|"tries"| F["Navigator Share API"]
  F -->|"fallback"| G["Twitter Intent URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>share.ts</strong><dd><code>X share helper with hashtag and fallback support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/lib/share.ts

<ul><li>Export constant <code>MAX_X_POST_LENGTH</code> set to 280 characters<br> <li> Implement <code>buildXShareText</code> function that composes share text with <br>title, summary, URL, and hashtags<br> <li> Add <code>sanitizeCategoryForHashtag</code> to normalize categories into valid <br>hashtags supporting CJK characters<br> <li> Implement <code>shareArticleToX</code> function with Web Share API support and <br>Twitter intent URL fallback<br> <li> Handle AbortError gracefully when user cancels share dialog</ul>


</details>


  </td>
  <td><a href="https://github.com/t1k2a/ai-news-reader-app-native/pull/6/files#diff-c23f2c334fa8540df7034f03acfa7336ec819bb3891c6f8cc24ceef43a4617cb">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ShareButton.tsx</strong><dd><code>Reusable ShareButton component for X sharing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/ShareButton.tsx

<ul><li>Create new reusable <code>ShareButton</code> component accepting share options and <br>custom styling<br> <li> Implement click handler that calls <code>shareArticleToX</code> with article <br>metadata<br> <li> Include X logo SVG icon and customizable label defaulting to "Xでシェア"<br> <li> Support className prop for flexible styling via <code>cn</code> utility<br> <li> Add proper accessibility attributes and event handling</ul>


</details>


  </td>
  <td><a href="https://github.com/t1k2a/ai-news-reader-app-native/pull/6/files#diff-5b27b7beb8a32ed956a17692ed6493dfddd032638d919e2464030e26d6d2fc91">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ArticleDetailView.tsx</strong><dd><code>Integrate ShareButton into article detail footer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/ArticleDetailView.tsx

<ul><li>Import new <code>ShareButton</code> component<br> <li> Calculate <code>shareSummary</code> from summary or first paragraph for share <br>functionality<br> <li> Refactor footer layout to flex container supporting responsive button <br>arrangement<br> <li> Add <code>ShareButton</code> with article data (title, URL, categories, summary)<br> <li> Style share button with border and hover effects for secondary action <br>appearance<br> <li> Maintain existing "read more" button with updated responsive classes</ul>


</details>


  </td>
  <td><a href="https://github.com/t1k2a/ai-news-reader-app-native/pull/6/files#diff-c4e17d6da975ceff084511905edcd7ea5c479510c6f820626576ba4ca321317e">+31/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

