### PR TITLE
feat: refresh button styling

### DIFF
--- a/client/src/components/BookmarkButton.tsx
+++ b/client/src/components/BookmarkButton.tsx
@@ -39,12 +39,13 @@ export function BookmarkButton({ article, className = '' }: BookmarkButtonProps)
   return (
     <button
       onClick={handleBookmarkToggle}
-      className={`text-sm p-2 rounded-full transition-colors ${
-        bookmarked 
-          ? 'text-yellow-400 hover:text-yellow-300' 
-          : 'text-slate-400 hover:text-slate-300'
+      className={`inline-flex items-center justify-center rounded-full border p-2 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${
+        bookmarked
+          ? 'border-amber-400/60 bg-amber-400/10 text-amber-300 shadow-[0_12px_28px_-20px_rgba(251,191,36,0.8)] hover:border-amber-300/80 hover:bg-amber-400/20 hover:text-amber-200 focus-visible:ring-amber-300'
+          : 'border-slate-600/60 bg-slate-700/40 text-slate-300 hover:border-slate-500 hover:bg-slate-600/60 hover:text-slate-200 focus-visible:ring-slate-300'
       } ${className}`}
       title={bookmarked ? 'ブックマークから削除' : 'ブックマークに追加'}
+      aria-label={bookmarked ? 'ブックマークから削除' : 'ブックマークに追加'}
     >
       {bookmarked ? (
         <svg 

--- a/client/src/components/BookmarksPanel.tsx
+++ b/client/src/components/BookmarksPanel.tsx
@@ -28,18 +28,19 @@ export function BookmarksPanel() {
       {!isOpen ? (
         <button
           onClick={() => setIsOpen(true)}
-          className="bg-blue-600 text-white p-3 rounded-full shadow-lg flex items-center gap-2 hover:bg-blue-700 transition-colors"
+          className="group flex items-center gap-2 rounded-full border border-transparent bg-gradient-to-r from-sky-500 via-indigo-500 to-purple-500 px-4 py-2 text-sm font-semibold text-white shadow-[0_18px_34px_-18px_rgba(79,70,229,0.9)] transition-all duration-200 hover:from-sky-600 hover:via-indigo-600 hover:to-purple-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
         >
-          <svg 
-            xmlns="http://www.w3.org/2000/svg" 
-            width="20" 
-            height="20" 
-            viewBox="0 0 24 24" 
-            fill="currentColor" 
-            stroke="currentColor" 
-            strokeWidth="2" 
-            strokeLinecap="round" 
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
             strokeLinejoin="round"
+            className="transition-transform duration-200 group-hover:scale-110"
           >
             <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
           </svg>
@@ -53,19 +54,20 @@ export function BookmarksPanel() {
               {bookmarks.length > 0 && (
                 <button
                   onClick={clearAllBookmarks}
-                  className="text-sm px-2 py-1 bg-red-500/20 text-red-400 rounded hover:bg-red-500/30 transition-colors"
+                  className="rounded-full border border-red-500/40 bg-red-500/10 px-3 py-1 text-xs font-medium text-red-200 transition-all duration-200 hover:border-red-400/70 hover:bg-red-500/20 hover:text-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
                 >
                   すべて削除
                 </button>
               )}
               <button
                 onClick={() => setIsOpen(false)}
-                className="text-slate-400 hover:text-slate-300"
+                className="inline-flex items-center justify-center rounded-full border border-slate-600/50 bg-slate-700/40 p-1 text-slate-300 transition-all duration-200 hover:border-slate-500 hover:bg-slate-600/60 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+                aria-label="ブックマークパネルを閉じる"
               >
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  width="20" 
-                  height="20" 
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
                   viewBox="0 0 24 24" 
                   fill="none" 
                   stroke="currentColor" 
@@ -102,8 +104,9 @@ export function BookmarksPanel() {
                     </a>
                     <button
                       onClick={() => removeBookmark(bookmark.id)}
-                      className="text-slate-400 hover:text-red-400 transition-colors"
+                      className="inline-flex items-center justify-center rounded-full border border-red-500/30 bg-red-500/10 p-1 text-red-300 transition-all duration-200 hover:border-red-400/70 hover:bg-red-500/20 hover:text-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
                       title="削除"
+                      aria-label="ブックマークから削除"
                     >
                       <svg 
                         xmlns="http://www.w3.org/2000/svg" 

--- a/client/src/components/NewContentBanner.tsx
+++ b/client/src/components/NewContentBanner.tsx
@@ -27,12 +27,12 @@ export function NewContentBanner({ newContentCount, onRefresh }: NewContentBanne
     <div className="fixed top-16 left-0 right-0 z-30 flex justify-center px-4 py-2 pointer-events-none">
       <button
         onClick={handleClick}
-        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-full shadow-lg transition-colors flex items-center gap-2 pointer-events-auto animate-bounce"
+        className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-transparent bg-gradient-to-r from-emerald-400 via-sky-500 to-indigo-500 px-5 py-2 text-sm font-semibold text-white shadow-[0_18px_38px_-18px_rgba(14,165,233,0.9)] transition-all duration-200 hover:from-emerald-500 hover:via-sky-600 hover:to-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 animate-bounce"
       >
-        <svg 
-          xmlns="http://www.w3.org/2000/svg" 
-          width="16" 
-          height="16" 
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
           viewBox="0 0 24 24" 
           fill="none" 
           stroke="currentColor" 

--- a/client/src/components/NewsHeader.tsx
+++ b/client/src/components/NewsHeader.tsx
@@ -33,7 +33,7 @@ export function NewsHeader() {
         
         <div className="text-sm text-gray-600 dark:text-slate-400 flex items-center">
           最終更新: {currentTime} JST
-          <button 
+          <button
             onClick={() => {
               setCurrentTime(new Intl.DateTimeFormat('ja-JP', {
                 year: 'numeric',
@@ -46,19 +46,21 @@ export function NewsHeader() {
               }).format(new Date()));
               window.location.reload();
             }}
-            className="ml-2 p-1 text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300"
+            className="group ml-3 inline-flex items-center justify-center rounded-full border border-blue-500/40 bg-blue-500/10 p-1.5 text-blue-500 shadow-[0_8px_16px_-12px_rgba(59,130,246,0.75)] transition-all duration-200 hover:border-blue-400/70 hover:bg-blue-500/20 hover:text-blue-300 dark:hover:text-blue-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
             title="ニュースを更新"
+            aria-label="ニュースを更新"
           >
-            <svg 
-              xmlns="http://www.w3.org/2000/svg" 
-              width="16" 
-              height="16" 
-              viewBox="0 0 24 24" 
-              fill="none" 
-              stroke="currentColor" 
-              strokeWidth="2" 
-              strokeLinecap="round" 
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
               strokeLinejoin="round"
+              className="transition-transform duration-200 group-hover:rotate-180 group-focus-visible:rotate-180"
             >
               <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
               <path d="M21 3v5h-5" />

--- a/client/src/components/NewsTimeline.tsx
+++ b/client/src/components/NewsTimeline.tsx
@@ -39,13 +39,26 @@ function CategoryButton({
   return (
     <button
       onClick={onClick}
-      className={`px-3 py-1 text-sm rounded-full transition-colors whitespace-nowrap border ${
+      className={`group relative overflow-hidden rounded-full border px-4 py-2 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${
         isSelected
-          ? 'bg-blue-600 text-white border-blue-500'
-          : 'bg-slate-700 text-slate-200 hover:bg-slate-600 border-slate-600/50'
+          ? 'border-transparent bg-gradient-to-r from-sky-500 via-indigo-500 to-purple-500 text-white shadow-[0_12px_30px_-15px_rgba(56,189,248,0.9)]'
+          : 'border-slate-700/60 bg-slate-800/60 text-slate-200 shadow-inner shadow-slate-900/40 hover:border-slate-500 hover:bg-slate-700/70 hover:text-white'
       }`}
     >
-      {category === null ? 'すべて' : category}
+      <span className="relative z-10 flex items-center gap-2">
+        {isSelected && (
+          <span className="inline-flex size-1.5 rounded-full bg-white/90 shadow-sm"></span>
+        )}
+        {category === null ? 'すべて' : category}
+      </span>
+      <span
+        aria-hidden
+        className={`absolute inset-0 rounded-full opacity-0 transition-opacity duration-200 group-hover:opacity-100 ${
+          isSelected
+            ? 'bg-white/10'
+            : 'bg-gradient-to-r from-slate-700/20 via-slate-600/10 to-slate-700/20'
+        }`}
+      />
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- refresh category filter chips with gradient highlights and clearer focus states
- restyle floating banner, header refresh action, bookmark buttons, and bookmarks panel controls for a cohesive button language
- add consistent accessibility affordances like focus rings and aria labels across interactive controls

## Testing
- npm run check *(fails: existing TypeScript configuration errors and unrelated type issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_690096c5094c832ab7efc68a1d6130eb