### PR TITLE
[CTR改善] スレッド形式（URL-in-Reply）を有効化してリーチを最大化 (#17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,18 @@ APP_BASE_URL=https://glotnexus.jp
 # - "random": ランダム（50/50でA/Bテスト）
 TWEET_FORMAT_VARIANT=enhanced
 
+# スレッド形式（URL-in-Reply）の有効化（Issue #17）
+# true: メインツイート（URLなし）+ リプライ（URLあり）の2ポスト構成
+#       → Xのアルゴリズムによる外部リンクペナルティを回避し、リーチを最大化
+# false: 従来の1ツイート形式（デフォルト）
+USE_THREAD_FORMAT=false
+
+# ブランドカード画像の有効化（Issue #18）
+# true: ツイートに自動生成した 1200x675px のブランドカード画像を添付
+#       → インプレッションを2〜3倍向上（canvas パッケージ必須）
+# false: テキストのみの投稿（デフォルト）
+USE_BRAND_CARD=false
+
 # ===========================================
 # Upstash Redis（サーバーレス環境用キャッシュ）
 # ===========================================


### PR DESCRIPTION
## 概要

`USE_THREAD_FORMAT=true` を Vercel 環境変数に設定することで、スレッド形式の投稿（メインツイート + リプライ）を有効化できる。スレッド形式の投稿ロジック（`lib/auto-post.ts` の `USE_THREAD_FORMAT` フラグと `lib/auto-post-enhanced.ts` の `formatTweetWithReplyAsync`）はすでに実装済みのため、`.env.example` に環境変数の文書化を追記するのが主な実装作業。

## 変更内容

- 変更: `.env.example` — `USE_THREAD_FORMAT` と `USE_BRAND_CARD` の環境変数エントリをコメント付きで追加

## テスト

- [x] `npm run check` でTypeScriptエラーなし（NO_TEST: 自動テストなし）
- [ ] 人間によるコードレビュー
- [ ] Vercel に `USE_THREAD_FORMAT=true` を設定して動作確認

## 完了条件

- [x] `.env.example` に `USE_THREAD_FORMAT` が文書化されている
- [x] `npm run check` でエラーなし

## Vercel 設定手順

Vercel ダッシュボードの Environment Variables に以下を設定してください：

```
USE_THREAD_FORMAT=true
```

これにより、投稿が以下の2ポスト構成になります：
- **メインツイート**: フック + 要約 + ハッシュタグ（URLなし）
- **リプライ**: 記事URL + 元記事リンク

Closes #17

---
🤖 このPRは Agent Team によって自動作成されました